### PR TITLE
add bundle validation for DocumentReference

### DIFF
--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -27,3 +27,8 @@ Invariant: ch-elm-leading-code
 Description: "The ServiceRequest.code and the Observation.code are in general equal."
 Severity: #warning
 Expression: "entry.resource.ofType(ServiceRequest).code = entry.resource.ofType(Observation).code"
+
+Invariant: ch-elm-urlconformstochelmbundle
+Description: "Must have a resolvable URL conforming to the CH-ELM Bundle."
+Severity: #error
+Expression: "url.exists() and url.resolve().conformsTo('http://fhir.ch/ig/ch-elm/StructureDefinition/ch-elm-document')"

--- a/input/fsh/profiles/Publish.fsh
+++ b/input/fsh/profiles/Publish.fsh
@@ -20,6 +20,8 @@ A profile on the DocumentReference resource with publication constraints:
 * securityLabel 0..* MS
 * content 1..1
 * content ^definition = "The document and format referenced"
+* content.attachment 1..1
+* content.attachment obeys ch-elm-urlconformstochelmbundle
 * content.attachment.language 0..1 MS
 * content.attachment.url 1..1
 * content.attachment.url ^short = "The document is referenced by this url, contained in the DocumentReference"

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -28,3 +28,6 @@ Entry 'http://test.fhir.ch/r4/DiagnosticReport/4DR-Campylobacter' isn't reachabl
 Entry 'http://test.fhir.ch/r4/DiagnosticReport/5DR-TreponemaPallidum' isn't reachable by traversing forwards from the Composition. Only Provenance is approved to be used this way (R4 section 3.3.1)
 Entry 'http://test.fhir.ch/r4/DiagnosticReport/6DR-Influenza' isn't reachable by traversing forwards from the Composition. Only Provenance is approved to be used this way (R4 section 3.3.1)
 Entry 'http://test.fhir.ch/r4/DiagnosticReport/7DR-SARSCoV2' isn't reachable by traversing forwards from the Composition. Only Provenance is approved to be used this way (R4 section 3.3.1)
+
+# open issue with IGPublisher https://github.com/ahdis/ch-elm/issues/28
+Error in constraint 'ch-elm-urlconformstochelmbundle' with expression 'url.exists() and url.resolve().conformsTo('http://fhir.ch/ig/ch-elm/StructureDefinition/ch-elm-document')': Error evaluating FHIRPath expression: The function resolve can only be used on ordered collections (@char 3)

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,6 +10,7 @@ All significant changes to this FHIR implementation guide will be documented on 
    * Profile [CH ELM Document: Laboratory Report](StructureDefinition-ch-elm-document.html): The leading code element has an [extensible](https://hl7.org/fhir/R4/terminologies.html#extensible) binding to the ValueSet CH ELM Results Laboratory Observation
       * Potential usage: A new leading code to be reported is introduced, which could not yet get updated in the implementation guide 
 * Include a check (warning) if Observation.code and ServiceRequest.code are equal (so far no other requirements)
+* Validation of Bundle for DocumentReference [#29](https://github.com/ahdis/ch-elm/issues/29)
 
 #### Changed / Updated
 * [#15](https://github.com/ahdis/ch-elm/issues/15): API update for search capabilities

--- a/test.http
+++ b/test.http
@@ -44,3 +44,51 @@ Accept: application/fhir+json
     }
   ]
 }
+
+### validaton
+
+POST http://localhost:8080/matchboxv3/fhir/$validate?profile=http://fhir.ch/ig/ch-elm/StructureDefinition/PublishDocumentReference HTTP/1.1
+Content-Type: application/fhir+json
+Accept: application/fhir+json
+
+{
+  "resourceType" : "DocumentReference",
+  "meta" : {
+    "profile" : [
+      "http://fhir.ch/ig/ch-elm/StructureDefinition/PublishDocumentReference"
+    ]
+  },
+  "contained" : [
+    {
+      "resourceType" : "Bundle",
+      "id" : "1Doc-NeisseriaGonorrhoeae",
+      "meta" : {
+        "profile" : [
+          "http://fhir.ch/ig/ch-elm/StructureDefinition/ch-elm-document",
+          "http://hl7.eu/fhir/laboratory/StructureDefinition/Bundle-eu-lab"
+        ]
+      },
+      "identifier" : {
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "urn:uuid:1901332d-6012-443f-9690-9291adb2e19d"
+      },
+      "type" : "document"       
+      // snip the rest of the bundle
+    }
+  ],
+  "identifier" : [
+    {
+      "system" : "urn:ietf:rfc:3986",
+      "value" : "urn:uuid:1901332d-6012-443f-9690-9291adb2e19d"
+    }
+  ],
+  "status" : "current",
+  "content" : [
+    {
+      "attachment" : {
+        "language" : "de-CH",
+        "url" : "#1Doc-NeisseriaGonorrhoeae"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
add the additional validation, IG Publisher shows currently an error, but it has been raised on zulip:

https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Error.20FHIRPath.3A.20resolve.20needs.20ordered.20collection.3F