### PR TITLE
add support for interpretation code #62

### DIFF
--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -47,3 +47,13 @@ Invariant: ch-elm-patient-name-representation-initial-snomedct
 Description: "If Observation.code is a mapped to initials in http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-foph-patient-name-representation then patient.name.first and given can must have one character"
 Severity: #error
 Expression: "'http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-foph-patient-name-representation'.resolve().group.where(source='http://snomed.info/sct').element.where(code=%context.code.coding.where(system='http://snomed.info/sct').first().code).target.first().code = 'initials' implies subject.resolve().name.first().family.length() = 1 and  subject.resolve().name.first().given.first().length() = 1"
+
+Invariant: ch-elm-interpretation-code-loinc
+Description: "If Observation.code is a mapped in http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code', then the interpretation code must be a member of the mapped ValueSet"
+Severity: #error
+Expression: "'http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code'.resolve().group.where(source='http://loinc.org').element.where(code=%context.code.coding.where(system='http://loinc.org').first().code).exists() implies interpretation.memberOf('http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code'.resolve().group.where(source='http://loinc.org').element.where(code=%context.code.coding.where(system='http://loinc.org').first().code).target.first().code)"
+
+Invariant: ch-elm-interpretation-code-snomedct
+Description: "If Observation.code is a mapped in http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code', then the interpretation code must be a member of the mapped ValueSet"
+Severity: #error
+Expression: "'http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code'.resolve().group.where(source='http://snomed.info/sct').element.where(code=%context.code.coding.where(system='http://snomed.info/sct').first().code).exists() implies interpretation.memberOf('http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code'.resolve().group.where(source='http://snomed.info/sct').element.where(code=%context.code.coding.where(system='http://snomed.info/sct').first().code).target.first().code)"

--- a/input/fsh/profiles/Observation.fsh
+++ b/input/fsh/profiles/Observation.fsh
@@ -5,6 +5,8 @@ Title: "CH ELM Observation Results: Laboratory"
 Description: "This CH ELM base profile constrains the Observation resource for the purpose of laboratory test reports."
 * obeys ch-elm-expecting-specimen-specification
 * obeys ch-elm-expecting-organism-specification
+* obeys ch-elm-interpretation-code-loinc
+* obeys ch-elm-interpretation-code-snomedct
 * . ^short = "CH ELM Observation Results: Laboratory"
 * status = #final
 * code from ChElmResultsLaboratoryObservation (extensible)
@@ -30,7 +32,6 @@ Description: "This CH ELM base profile constrains the Observation resource for t
 * interpretation 1..1
 * interpretation from ChElmObservationInterpretationCodes (required)
 * interpretation only ChElmCodeableConcept
-
 
 
 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,5 +1,10 @@
 All significant changes to this FHIR implementation guide will be documented on this page.   
 
+### 1.2.0 - cibuild 
+
+* [#32](https://github.com/ahdis/ch-elm/issues/62): adding ValueSets/ConceptMaps for Interpretation Code
+
+
 ### 1.1.0 2024/01/31
 
 #### Added

--- a/input/pagecontent/guidance.md
+++ b/input/pagecontent/guidance.md
@@ -89,5 +89,9 @@ In some cases, an additional organism must be specified.
 
 {% include img.html img="expecting-organism-specification.png" caption="Fig. 8: Schematic illustration of the mechanism for the expecting organism specification (for simplicity, only the relevant elements are shown)" width="100%" %}  
 
+##### Interpretation Codes
+Depending on the leading code different interpretation codes are allowed. The [ConceptMap](ConceptMap-ch-elm-results-to-interpretation-code.html) specifies which values from which ValueSet
+are allowed (e.g. for Neisseria gonorrhoeae the [ValueSet: CH ELM Interpretation Codes Positive ](ValueSet-ch-elm-interpretation-codes-pos.html) is specified, which allows only a positive interpretation code to be specified).
+
 ### Multiplex Cases
 The exchange format defines the [FHIR document](document.html) for reporting to the FOPH so that **one document per organism per patient** is submitted. 

--- a/input/resources/CodeSystem-ch-elm-interpretation-codes-vs.json
+++ b/input/resources/CodeSystem-ch-elm-interpretation-codes-vs.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "ch-elm-interpretation-codes-vs",
+  "url": "http://fhir.ch/ig/ch-elm/CodeSystem/ch-elm-interpretation-codes-vs",
+  "version": "2024-01-31",
+  "name": "ChElmInterpretationCodeVs",
+  "title": "CH ELM Interpretation Codes Vs",
+  "status": "active",
+  "experimental": false,
+  "description": "This CH ELM code system defines the value set URLs as Interpretation Codes to map in the concept maps the leading codes.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "CHE"
+        }
+      ]
+    }
+  ],
+  "caseSensitive": false,
+  "content": "complete",
+  "concept": [
+    {
+      "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos"
+    },
+    {
+      "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos-neg"
+    },
+    {
+      "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-resitant-susceptible"
+    }  ]
+}

--- a/input/resources/ConceptMap-ch-elm-results-to-interpretation-code.json
+++ b/input/resources/ConceptMap-ch-elm-results-to-interpretation-code.json
@@ -1,0 +1,541 @@
+{
+  "resourceType": "ConceptMap",
+  "id": "ch-elm-results-to-interpretation-code",
+  "url": "http://fhir.ch/ig/ch-elm/ConceptMap/ch-elm-results-to-interpretation-code",
+  "version": "2024-01-31",
+  "name": "ChElmResultsToInterpretationCode",
+  "title": "CH ELM Results To Interpretation Code",
+  "status": "active",
+  "experimental": false,
+  "description": "This CH ELM concept map specifies the interpretation codes for each leading code. E.g. if positive, positive and negative or resistant-susceptible values are allowed  ",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "CHE"
+        }
+      ]
+    }
+  ],
+  "sourceCanonical": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-results-laboratory-observation",
+  "targetCanonical": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-ch-elm-interpretation-codes-vs",
+  "group": [
+    {
+      "source": "http://loinc.org",
+      "target": "http://fhir.ch/ig/ch-elm/CodeSystem/ch-elm-ch-elm-interpretation-codes-vs",
+      "element": [
+        {
+          "code": "14127-5",
+          "display": "Neisseria gonorrhoeae [Presence] in Anal by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "14463-4",
+          "display": "Chlamydia trachomatis [Presence] in Cervix by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "14464-2",
+          "display": "Chlamydia trachomatis [Presence] in Vaginal fluid by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "14465-9",
+          "display": "Chlamydia trachomatis [Presence] in Urethra by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "16600-9",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Genital specimen by Probe",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "21190-4",
+          "display": "Chlamydia trachomatis DNA [Presence] in Cervix by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "21191-2",
+          "display": "Chlamydia trachomatis DNA [Presence] in Urethra by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "21415-5",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Urethra by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "21416-3",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Urine by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "21613-5",
+          "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "23838-6",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Genital fluid by Probe",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "24111-7",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "31777-6",
+          "display": "Chlamydia trachomatis Ag [Presence] in Specimen",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "32705-6",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Vaginal fluid by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "42931-6",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Urine by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "43304-5",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Specimen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "43305-2",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Specimen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "45084-1",
+          "display": "Chlamydia trachomatis DNA [Presence] in Vaginal fluid by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "45090-8",
+          "display": "Chlamydia trachomatis DNA [Presence] in Anal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "45093-2",
+          "display": "Chlamydia trachomatis [Presence] in Anal by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "45095-7",
+          "display": "Chlamydia trachomatis [Presence] in Genital specimen by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "47387-6",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Genital specimen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "50387-0",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Cervix by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "50388-8",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Cervix by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "51578-3",
+          "display": "Chlamydia trachomatis DNA [Presence] in Semen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "53879-3",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Vaginal fluid by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "53925-4",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Urethra by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "53926-2",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Vaginal fluid by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "53927-0",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Urethra by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "57287-5",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Anal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "57458-2",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Anal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "60255-7",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Throat by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "60256-5",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Urine by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "6349-5",
+          "display": "Chlamydia trachomatis [Presence] in Specimen by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "6356-0",
+          "display": "Chlamydia trachomatis DNA [Presence] in Genital specimen by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "6357-8",
+          "display": "Chlamydia trachomatis DNA [Presence] in Urine by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "688-2",
+          "display": "Neisseria gonorrhoeae [Presence] in Cervix by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "691-6",
+          "display": "Neisseria gonorrhoeae [Presence] in Genital specimen by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "693-2",
+          "display": "Neisseria gonorrhoeae [Presence] in Vaginal fluid by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "694-0",
+          "display": "Neisseria gonorrhoeae [Presence] in Semen by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "696-5",
+          "display": "Neisseria gonorrhoeae [Presence] in Throat by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "697-3",
+          "display": "Neisseria gonorrhoeae [Presence] in Urethra by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "698-1",
+          "display": "Neisseria gonorrhoeae [Presence] in Specimen by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "80363-5",
+          "display": "Chlamydia trachomatis DNA [Presence] in Anorectal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "80364-3",
+          "display": "Chlamydia trachomatis rRNA [Presence] in Anorectal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "80366-8",
+          "display": "Neisseria gonorrhoeae rRNA [Presence] in Anorectal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "80367-6",
+          "display": "Chlamydia trachomatis [Presence] in Anorectal by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "80368-4",
+          "display": "Neisseria gonorrhoeae [Presence] in Anorectal by Organism specific culture",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "88224-1",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Anorectal by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "88225-8",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Throat by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        },
+        {
+          "code": "96599-6",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Cervix by NAA with probe detection",
+          "target": [
+            {
+              "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+              "equivalence": "relatedto"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/input/resources/ValueSet-ch-elm-interpretation-codes-pos-neg.json
+++ b/input/resources/ValueSet-ch-elm-interpretation-codes-pos-neg.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "ValueSet",
+  "id": "ch-elm-interpretation-codes-pos-neg",
+  "url": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos-neg",
+  "version": "2024-01-31",
+  "name": "ChElmInterpretationCodesPosNeg",
+  "title": "CH ELM Interpretation Codes Positive and Negative",
+  "status": "active",
+  "experimental": false,
+  "description": "This CH ELM value set includes the code for positive and negative interpretation codes.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "concept": [
+          {
+            "code": "POS",
+            "display": "Positive"
+          },
+          {
+            "code": "NEG",
+            "display": "Negative"}
+        ]
+      }
+    ]
+  }
+}

--- a/input/resources/ValueSet-ch-elm-interpretation-codes-pos.json
+++ b/input/resources/ValueSet-ch-elm-interpretation-codes-pos.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "ValueSet",
+  "id": "ch-elm-interpretation-codes-pos",
+  "url": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos",
+  "version": "2024-01-31",
+  "name": "ChElmInterpretationCodesPos",
+  "title": "CH ELM Interpretation Codes Positive",
+  "status": "active",
+  "experimental": false,
+  "description": "This CH ELM value set includes the code for positive interpretation code.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "concept": [
+          {
+            "code": "POS",
+            "display": "Positive"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/resources/ValueSet-ch-elm-interpretation-codes-resistant-susceptible.json
+++ b/input/resources/ValueSet-ch-elm-interpretation-codes-resistant-susceptible.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "ValueSet",
+  "id": "ch-elm-interpretation-codes-resistant-susceptible",
+  "url": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-resistant-susceptible",
+  "version": "2024-01-31",
+  "name": "ChElmInterpretationCodesResistantSusceptible",
+  "title": "CH ELM Interpretation Codes resistant and susceptible",
+  "status": "active",
+  "experimental": false,
+  "description": "This CH ELM value set includes the code for resistant and susceptible interpretation codes.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "concept": [
+          {
+            "code": "R",
+            "display": "Resistant"
+          },
+          {
+            "code": "S",
+            "display": "Susceptible"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/resources/ValueSet-ch-elm-interpretation-codes-vs.json
+++ b/input/resources/ValueSet-ch-elm-interpretation-codes-vs.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "ValueSet",
+  "id": "ch-elm-interpretation-codes-vs",
+  "url": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-vs",
+  "version": "2024-01-31",
+  "name": "ChElmInterpretationCodeVs",
+  "title": "CH ELM Interpretation Codes Vs",
+  "status": "active",
+  "experimental": false,
+  "description": "This CH ELM value set includes the value set URLs as interpretation codes to map in the concept maps the leading codes.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://fhir.ch/ig/ch-elm/CodeSystem/ch-elm-interpretation-codes-vs",
+        "concept": [
+          {
+            "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos"
+          },
+          {
+            "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-pos-neg"
+          },
+          {
+            "code": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-interpretation-codes-resitant-susceptible"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
#62 

Depending on the leading code different interpretation codes are allowed. The ConceptMap ConceptMap-ch-elm-results-to-interpretation-code specifies which values from which ValueSet
are allowed (e.g. for Neisseria gonorrhoeae the [ValueSet: CH ELM Interpretation Codes Positive ](ValueSet-ch-elm-interpretation-codes-pos.html) is specified, which allows only a positive interpretation code to be specified).

This is a draft PR, the mapping form the leading code to the interpretation code needs to be provided by FOPH.