### PR TITLE
Remove constraint on practitioner-orderer.telecom cardinality

### DIFF
--- a/input/fsh/profiles/Practitioner.fsh
+++ b/input/fsh/profiles/Practitioner.fsh
@@ -12,11 +12,11 @@ Description: "This CH ELM base profile constrains the Practitioner resource for 
 * name.given ^maxLength = 100
 * name.family MS
 * name.family ^maxLength = 100
-* telecom[email] ..1 MS
+* telecom[email] MS
 * telecom[email].value ^example.label = "CH ELM"
 * telecom[email].value ^example.valueString = "info@domain.ch"
 * telecom[email].value ^maxLength = 255
-* telecom[phone] ..1 MS
+* telecom[phone] MS
 * telecom[phone].value ^example.label = "CH ELM"
 * telecom[phone].value ^example.valueString = "+41 79 999 55 66"
 * telecom[phone].value ^maxLength = 25

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,7 +10,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#89](https://github.com/ahdis/ch-elm/issues/89): add ServiceRequest.requisition for referencing original order id
 * [#103](https://github.com/ahdis/ch-elm/issues/103): change patient id references with serial numbers
 * [#102](https://github.com/ahdis/ch-elm/issues/102): patient.street, patient.telecom only allowed for full name representation 
-
+* [#104](https://github.com/ahdis/ch-elm/issues/104): remover practitioner-orderer.telecom constraint 0..1
 
 ### 1.3.1 2024/06/17 
 


### PR DESCRIPTION
This pull request removes the constraint on the cardinality of the `practitioner-orderer.telecom` field, changing it from 0..1 to 0..*. This change addresses issue #104.