### PR TITLE
Replace gene by geno in source of ConceptMap-ch-elm-results-geno-to-component-code.json

### DIFF
--- a/input/resources/ConceptMap-ch-elm-results-geno-to-component-code.json
+++ b/input/resources/ConceptMap-ch-elm-results-geno-to-component-code.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "sourceCanonical": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-results-laboratory-observation-gene",
+  "sourceCanonical": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-results-laboratory-observation-geno",
   "targetCanonical": "http://fhir.ch/ig/ch-elm/ValueSet/ch-elm-results-component-vs",
   "group": [
     {


### PR DESCRIPTION
As the name suggests, correct typo.